### PR TITLE
Updated to remove warnings

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "script" {
 }
 
 variable "file_uris" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of files to be downloaded."
 }


### PR DESCRIPTION
"list" is depricated 
new standard is list(string) to specify a list of strings.